### PR TITLE
bumps dependency to work with node 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "browserify-transform-tools": "~1.4.2",
     "lodash": "~3.10.1",
-    "node-sass": "~3.2.0",
+    "node-sass": "^3.3.3",
     "postcss": "~4.1.11",
     "resolve": "^1.1.6"
   }


### PR DESCRIPTION
If you have the lastest version of node, the install will fail. According to this  [comment](https://github.com/sass/node-sass/issues/1122#issuecomment-143020384) by the package maintainer, bumping to ^3.3.3 will fix the issue.
