### PR TITLE
allowing for importer factory functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,10 @@ function scssify(file, content, config, stream, done) {
   if (typeof sassOpts.importer === 'string') {
     sassOpts.importer = require(path.resolve(sassOpts.importer))
   }
+  else if (typeof sassOpts.importerFactory === 'string') {
+    let factory = require(path.resolve(sassOpts.importerFactory))
+    sassOpts.importer = factory()
+  }
 
   if (options.autoInject === true) {
     options.autoInject = merge({}, DEFAULT_CONFIG.autoInject)

--- a/tests/custom-importers.js
+++ b/tests/custom-importers.js
@@ -3,6 +3,7 @@
 const assert = require('assert')
 const integration = require('./util/integration')
 const importSpy = require('./util/mock-importer').importedFiles
+const factory = require('./util/mock-importer-factory')
 
 before(function setup() {
   importSpy.clear()
@@ -18,3 +19,21 @@ it('loads custom importer files', integration(__dirname + '/util/imports.scss', 
   assert.equal(files.next().value, 'vars', 'import spy was loaded')
   done()
 }))
+
+it('loads importer from factory function every time it runs', function (done) {
+  // this mimics browserify + factor-bundle calling the transform several times in a single process
+  let file = __dirname + '/util/imports.scss'
+  let config = {
+    autoInject: false,
+    sass: {
+      importerFactory: 'tests/util/mock-importer-factory.js'
+    }
+  }
+  integration(file, config, function (context, done) {
+    integration(file, config, function (context, done) {
+      let count = factory.count
+      assert.equal(count, 2, 'factory not called expected number of times')
+      done()
+    })(done)
+  })(done)
+});

--- a/tests/util/mock-importer-factory.js
+++ b/tests/util/mock-importer-factory.js
@@ -1,0 +1,9 @@
+'use strict'
+const mockImporter = require('./mock-importer')
+module.exports = function () {
+  module.exports.count++;
+  return mockImporter
+}
+
+module.exports.count = 0;
+


### PR DESCRIPTION
This will let the importer state be reset if scssify is called several times within the same process, e.g. by factor-bundle
