### PR TITLE
source maps: if debug flag is set, only enable source maps by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,15 +7,20 @@ const TransformStream = require('stream').Transform
 const CWD = process.cwd()
 const TARGET_FILE_EXT = /\.(css|scss|sass)$/
 const MODULE_NAME = path.basename(path.dirname(__dirname))
-const DEFAULT_CONFIG = {
-  autoInject: true,
-  sass: {
-    outputStyle: 'compressed'
-  }
-}
 
 function scssify(file, content, config, stream, done) {
-  const options = merge({}, DEFAULT_CONFIG, config)
+  const defaults = {
+    autoInject: true,
+    sass: config._flags && config._flags.debug ? {
+      // "browserify --debug" was used, enable CSS sourcemaps by default
+      sourceMapEmbed: true,
+      sourceMapContents: true,
+      outputStyle: 'nested'
+    } : {
+      outputStyle: 'compressed'
+    }
+  }
+  const options = merge({}, defaults, config)
   const sassOpts = merge({}, options.sass)
   let postcss = null
   sassOpts.includePaths = sassOpts.includePaths || []
@@ -29,12 +34,6 @@ function scssify(file, content, config, stream, done) {
   }
   else if (typeof sassOpts.importerFactory === 'string') {
     sassOpts.importer = require(path.resolve(sassOpts.importerFactory))()
-  }
-  if (config._flags.debug) {
-    // "browserify --debug" was used, enable CSS sourcemaps!
-    sassOpts.sourceMapEmbed = true
-    sassOpts.sourceMapContents = true
-    sassOpts.outputStyle = 'nested'
   }
   if (options.postcss && typeof options.postcss !== 'object') {
     return done(new Error('postcss config must be false or an object of plugins'))


### PR DESCRIPTION
Before, the browserify debug flag being set would enable source maps, overriding any
user options.

Now, user options are still king, even if the debug flag is on.
