### PR TITLE
Update to node-sass 3.10.1 (support Node 7.X)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "postcss": "^5.1.2"
   },
   "dependencies": {
-    "node-sass": "^3.3.3",
+    "node-sass": "^3.10.1",
     "resolve": "^1.1.6"
   }
 }


### PR DESCRIPTION
Also a number of other fixes, but main concern is supporting node 7.X (at least node-sass 3.7.0).

Would like to switch from sassify due to better watchify support, but need node 7 support. :)