### PR TITLE
Add check for firstResult.map

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ function scssify(file, content, config, stream, done) {
       postcss(postcssTransforms).process(firstResult.css, {
         map: {
           inline: sassOpts.sourceMapEmbed,
-          prev: sassOpts.sourceMapEmbed ? firstResult.map.toString() : null
+          prev: sassOpts.sourceMapEmbed && firstResult.map ? firstResult.map.toString() : null
         }
       }).then(generateModule).catch(done)
     }


### PR DESCRIPTION
When running scssify with postcss plugins, in my case autoprefixer, under [budo](https://github.com/mattdesl/budo), it crashes from unknown reasons. I haven't got time to investigate further as of now, but this keeps it from crashing at least.