### PR TITLE
Auto inject options

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,29 +1,21 @@
 'use strict'
 /*eslint-env browser */
 
-function getHead() {
-  return document.head || document.getElementsByTagName('head')[0]
-}
-
-function attachAttributes(tag, attributes) {
-  for (var key in attributes) if (attributes.hasOwnProperty(key)) {
-    tag.setAttribute('data-' + key, attributes[key])
-  }
-}
-
 module.exports = {
   /**
    * Create a <style>...</style> tag and add it to the document head
    * @param {string} cssText
-   * @param {object?} attributes Optional data-* attribs
-   * @return {window.Element}
+   * @param {object?} options
+   * @return {Element}
    */
   createStyle: function (cssText, options) {
+    var container = document.head || document.getElementsByTagName('head')[0]
     var style = document.createElement('style')
-    var position = options.prepend === true ? 'prepend' : 'append'
-    var container = getHead()
+    options = options || {}
     style.type = 'text/css'
-    attachAttributes(style, options.verbose)
+    if (options.href) {
+      style.setAttribute('data-href', options.href)
+    }
     if (style.sheet) { // for jsdom and IE9+
       style.innerHTML = cssText
       style.sheet.cssText = cssText
@@ -34,7 +26,7 @@ module.exports = {
     else { // for Chrome, Firefox, and Safari
       style.appendChild(document.createTextNode(cssText))
     }
-    if (position === 'prepend') {
+    if (options.prepend) {
       container.insertBefore(style, container.childNodes[0]);
     } else {
       container.appendChild(style);

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -18,22 +18,26 @@ module.exports = {
    * @param {object?} attributes Optional data-* attribs
    * @return {window.Element}
    */
-  createStyle: function (cssText, attributes) {
+  createStyle: function (cssText, options) {
     var style = document.createElement('style')
+    var position = options.prepend === true ? 'prepend' : 'append'
+    var container = getHead()
     style.type = 'text/css'
-    attachAttributes(style, attributes)
+    attachAttributes(style, options.verbose)
     if (style.sheet) { // for jsdom and IE9+
       style.innerHTML = cssText
       style.sheet.cssText = cssText
-      getHead().appendChild(style)
     }
     else if (style.styleSheet) { // for IE8 and below
-      getHead().appendChild(style)
       style.styleSheet.cssText = cssText
     }
     else { // for Chrome, Firefox, and Safari
       style.appendChild(document.createTextNode(cssText))
-      getHead().appendChild(style)
+    }
+    if (position === 'prepend') {
+      container.insertBefore(style, container.childNodes[0]);
+    } else {
+      container.appendChild(style);
     }
     return style
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,9 @@ const CWD = process.cwd()
 const TARGET_FILE_EXT = /\.(css|scss|sass)$/
 const MODULE_NAME = path.basename(path.dirname(__dirname))
 const DEFAULT_CONFIG = {
-  autoInject: true,
+  autoInject: {
+    prepend: false
+  },
   sass: {
     outputStyle: 'compressed'
   }
@@ -71,8 +73,10 @@ function scssify(file, content, config, stream, done) {
       cssString = JSON.stringify(cssString)
       let out = ''
       if (options.autoInject) {
-        const verbose = options.autoInject === 'verbose' ? JSON.stringify({href}) : '{}'
-        out += `module.exports.tag = require('${MODULE_NAME}').createStyle(${cssString}, ${verbose});`
+        let autoInject = options.autoInject
+        autoInject.verbose = autoInject.verbose === true ? {href} : {}
+        autoInject = JSON.stringify(autoInject);
+        out += `module.exports.tag = require('${MODULE_NAME}').createStyle(${cssString}, ${autoInject});`
       }
       if (options.export || !options.autoInject) {
         out += `module.exports.css = ${cssString};`

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,7 @@ const CWD = process.cwd()
 const TARGET_FILE_EXT = /\.(css|scss|sass)$/
 const MODULE_NAME = path.basename(path.dirname(__dirname))
 const DEFAULT_CONFIG = {
-  autoInject: {
-    prepend: false
-  },
+  autoInject: true,
   sass: {
     outputStyle: 'compressed'
   }
@@ -73,10 +71,11 @@ function scssify(file, content, config, stream, done) {
       cssString = JSON.stringify(cssString)
       let out = ''
       if (options.autoInject) {
-        let autoInject = options.autoInject
-        autoInject.verbose = autoInject.verbose === true ? {href} : {}
-        autoInject = JSON.stringify(autoInject);
-        out += `module.exports.tag = require('${MODULE_NAME}').createStyle(${cssString}, ${autoInject});`
+        let autoInjectOptions = JSON.stringify({
+          href: (options.autoInject === 'verbose' || options.autoInject.verbose) && href,
+          prepend: options.autoInject.prepend
+        })
+        out += `module.exports.tag = require('${MODULE_NAME}').createStyle(${cssString}, ${autoInjectOptions});`
       }
       if (options.export || !options.autoInject) {
         out += `module.exports.css = ${cssString};`

--- a/readme.md
+++ b/readme.md
@@ -21,18 +21,25 @@ console.log('MyComponent background is blue')
 ```
 
 #### Settings
-The default settings are listed below.
 
 ```javascript
 const browserify = require('browserify')
 const scssify = require('scssify')
 browserify('entry.js')
   .transform(scssify, {
-    // Disable <style> injection
-    autoInject: false,
+    // Disable/enable <style> injection; true by default
+    autoInject: true,
 
     // Useful for debugging; adds data-href="src/foo.scss" to <style> tags
     autoInject: 'verbose',
+
+    // This can be an object too
+    autoInject: {
+      verbose: false,
+
+      // If true the <style> tag will be prepended to the <head>
+      prepend: false
+    },
 
     // require('./MyComponent.scss').css === '.MyComponent{color:red;background:blue}'
     // autoInject: false, will also enable this

--- a/tests/style-tag.js
+++ b/tests/style-tag.js
@@ -12,3 +12,17 @@ it('supports <style> tags', integration(__dirname + '/util/basic.scss', {
   assert.equal(applied.color, 'red', 'text color changed')
   done()
 }))
+
+it('can prepend to the <head>', integration(__dirname + '/util/basic.scss', {
+  autoInject: {prepend: true}
+}, function (ctx, done) {
+  let children = ctx.document.head.childNodes
+  let dummy = children[1]
+  assert.equal(children.length, 2)
+  assert.equal(dummy.id, 'foo')
+  done()
+}, function (ctx) {
+  let dummy = ctx.document.createElement('style')
+  dummy.id = 'foo'
+  ctx.document.head.appendChild(dummy)
+}))

--- a/tests/util/integration.js
+++ b/tests/util/integration.js
@@ -9,9 +9,10 @@ const CLIENT_HELPER_CODE = fs.readFileSync('lib/browser.js', 'utf8')
  * @param {string} src Absolute path to a scss file
  * @param {object} config scssify parameters
  * @param {function} callback(context, assert)
+ * @param {function?} prepare(context)
  * @return {function} Pass this to tape('test-name', fn)
  */
-function createIntegrationTest(src, config, callback) {
+function createIntegrationTest(src, config, callback, prepare) {
   if (!config._flags) config._flags = {}
   return function (done) {
     fs.createReadStream(src)
@@ -26,6 +27,11 @@ function createIntegrationTest(src, config, callback) {
         window: doc.defaultView,
         document: doc,
         module: helperModule
+      })
+      if (prepare) prepare({
+        window: doc.defaultView,
+        document: doc,
+        exports: cssModule.exports
       })
       vm.runInNewContext(transformed.toString(), {
         window: doc.defaultView,


### PR DESCRIPTION
In some cases we need to control the position to insert result css file.
In my case i'm need to build small independent bundles with included base style.

Add `autoInject` options:
````js
autoInject: {
  prepend: true/false,
  verbose: true/false
}
````
`prepend` - position in `head` tag. If `true` styles includes before all content. Default `false`.
`verbose` - as usual.