### PR TITLE
Allow raw output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,15 +70,20 @@ function scssify(file, content, config, stream, done) {
       }
       cssString = JSON.stringify(cssString)
       let out = ''
-      if (options.autoInject) {
-        let autoInjectOptions = JSON.stringify({
-          href: (options.autoInject === 'verbose' || options.autoInject.verbose) && href,
-          prepend: options.autoInject.prepend
-        })
-        out += `module.exports.tag = require('${MODULE_NAME}').createStyle(${cssString}, ${autoInjectOptions});`
-      }
-      if (options.export || !options.autoInject) {
-        out += `module.exports.css = ${cssString};`
+      if (options.raw) {
+        out += `module.exports = ${cssString};`
+      } else {
+        if (options.autoInject) {
+          let autoInjectOptions = JSON.stringify({
+            href: (options.autoInject === 'verbose' || options.autoInject.verbose) && href,
+            prepend: options.autoInject.prepend
+          })
+          out += `module.exports.tag = require('${MODULE_NAME}').createStyle(${cssString}, ${autoInjectOptions});`
+        }
+        
+        if (options.export || !options.autoInject) {
+          out += `module.exports.css = ${cssString};`
+        }
       }
       emitDependencies(stream, firstResult.stats.includedFiles)
       stream.push(out)


### PR DESCRIPTION
It allows simpler and more consistent with `webpack` imports like:

```
consoel.log(require('style.css))
> "body { color: red; }"
```