### PR TITLE
Adds check before displaying postcss warnings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,9 @@ function scssify(file, content, config, stream, done) {
     else generateModule(firstResult)
     function generateModule(result) {
       // Show any postcss warnings
-      result.warnings().forEach(item => console.error(item.toString()))
+      if (result.warnings) {
+        result.warnings().forEach(item => console.error(item.toString()))
+      }  
 
       let href = path.relative(CWD, file)
       let cssString = result.css.toString()


### PR DESCRIPTION
result.warnings() function only exists when using postcss.