### PR TITLE
(build) fix sass version to 1.57.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "postcss": "^6.0.13"
   },
   "dependencies": {
-    "node-sass": "npm:sass@1.57.1",
+    "node-sass": "npm:sass@1.58.3",
     "resolve": "^1.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "postcss": "^6.0.13"
   },
   "dependencies": {
-    "node-sass": "^4.5.3",
+    "node-sass": "npm:sass@^1.49.11",
     "resolve": "^1.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "postcss": "^6.0.13"
   },
   "dependencies": {
-    "node-sass": "npm:sass@^1.49.11",
+    "node-sass": "npm:sass@1.57.1",
     "resolve": "^1.1.6"
   }
 }


### PR DESCRIPTION
To address issues introduced in 1.58 where it uses nullish coalescing `??` operators in the javascript code, which is not supported by node 10 (eos)